### PR TITLE
链接的相对路径修改为绝对路径

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,8 @@
 - [ ] 原创，我申明当前 PR 中的文章是由我本人创作
 - [ ] 翻译，为了方便大家 Review，我已经把原文地址拷贝到了[这里](https://jenkins-zh.cn/)
     - [ ] 我已阅读[翻译规范](https://github.com/jenkins-zh/translation-spec)
-- [ ] 我已阅读[文章发布规则](management/operators/README.md)
-- [ ] 我已阅读[文章编写格式](articles/README.md)
+- [ ] 我已阅读[文章发布规则](https://github.com/jenkins-infra/wechat/tree/master/management/operators/README.md)
+- [ ] 我已阅读[文章编写格式](https://github.com/jenkins-infra/wechat/tree/master/articles/README.md)
 - [ ] 维护
 
 ### 发布


### PR DESCRIPTION
文章发布规则和文章编写格式的链接在 PR 中404
将相对路径修改为绝对路径

### PR 类型*

- [ ] 原创，我申明当前 PR 中的文章是由我本人创作
- [ ] 翻译，为了方便大家 Review，我已经把原文地址拷贝到了[这里](https://jenkins-zh.cn/)
    - [ ] 我已阅读[翻译规范](https://github.com/jenkins-zh/translation-spec)
- [ ] 我已阅读[文章发布规则](https://github.com/jenkins-infra/wechat/tree/master/management/operators/README.md)
- [ ] 我已阅读[文章编写格式](https://github.com/jenkins-infra/wechat/tree/master/articles/README.md)
- [x] 维护
